### PR TITLE
devices: fix case where model is a string not a set

### DIFF
--- a/devices/__init__.py
+++ b/devices/__init__.py
@@ -65,7 +65,15 @@ def initialize_devices(configuration):
 def get_device(model, **kwargs):
     for device_file, devs in device_mappings.iteritems():
         for dev in devs:
-            if 'model' in dev.__dict__ and model in dev.__dict__['model']:
+            if 'model' in dev.__dict__:
+
+                attr = dev.__dict__['model']
+
+                if type(attr) is str and model != attr:
+                    continue
+                elif type(attr) is tuple and model not in attr:
+                    continue
+
                 try:
                     return dev(model, **kwargs)
                 except KeyboardInterrupt:


### PR DESCRIPTION
If model is just a string (which a set of one string gets reduced to a
string for some reason) then substrings will start to match so model
ap148 will match ap148-nor device class. So we need to handle this case
to make the devices stay the same

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>